### PR TITLE
Match scan capture groups behaviour to Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ require "rust_regexp"
 Regular expressions should be pre-compiled before use:
 
 ```ruby
-re = RustRegexp.new('(\w+):(\d+)')
+re = RustRegexp.new('p.t{2}ern*')
 # => #<RustRegexp:...>
 ```
 
@@ -41,31 +41,37 @@ re = RustRegexp.new('(\w+):(\d+)')
 To find a single match in the haystack:
 
 ```ruby
-re.match("ruby:123, rust:456")
+RustRegexp.new('\w+:\d+').match("ruby:123, rust:456")
+# => ["ruby:123"]
+
+RustRegexp.new('(\w+):(\d+)').match("ruby:123, rust:456")
 # => ["ruby", "123"]
 ```
 
 To find all matches in the haystack:
 
 ```ruby
-re.scan("ruby:123, rust:456")
+RustRegexp.new('\w+:\d+').scan("ruby:123, rust:456")
+# => ["ruby:123", "rust:456"]
+
+RustRegexp.new('(\w+):(\d+)').scan("ruby:123, rust:456")
 # => [["ruby", "123"], ["rust", "456"]]
 ```
 
 To check whether there is at least one match in the haystack:
 
 ```ruby
-re.match?("ruby:123")
+RustRegexp.new('\w+:\d+').match?("ruby:123")
 # => true
 
-re.match?("ruby")
+RustRegexp.new('\w+:\d+').match?("ruby")
 # => false
 ```
 
 Inspect original pattern:
 
 ```ruby
-re.pattern
+RustRegexp.new('\w+:\d+').pattern
 # => "(\\w+):(\\d+)"
 ```
 
@@ -94,18 +100,18 @@ set.match("ghidefabc") # => [0, 1, 2]
 To check whether at least one pattern from the set matches the haystack:
 
 ```ruby
-set.match?("abc")
+RustRegexp::Set.new(["abc", "def"]).match?("abc")
 # => true
 
-set.match?("123")
+RustRegexp::Set.new(["abc", "def"]).match?("123")
 # => false
 ```
 
 Inspect original patterns:
 
 ```ruby
-set.patterns
-# => ["abc", "def", "ghi", "xyz"]
+RustRegexp::Set.new(["abc", "def"]).patterns
+# => ["abc", "def"]
 ```
 
 ## Development

--- a/ext/rust_regexp/src/lib.rs
+++ b/ext/rust_regexp/src/lib.rs
@@ -33,6 +33,7 @@ impl RustRegexp {
         let regex = &self.0;
         let haystack = unsafe { haystack.as_slice() };
 
+        // no capture groups defined except the default one
         if regex.captures_len() == 1 {
             // speed optimization, `.find` is faster than `.captures`
             if let Some(capture) = regex.find(haystack) {
@@ -65,17 +66,12 @@ impl RustRegexp {
         let regex = &self.0;
         let haystack = unsafe { haystack.as_slice() };
 
+        // no capture groups defined except the default one
         if regex.captures_len() == 1 {
             // speed optimization, `.find_iter` is faster than `.captures_iter`
             for capture in regex.find_iter(haystack) {
-                let group = RArray::with_capacity(1);
-
-                group
-                    .push(Self::capture_to_ruby_string(&capture))
-                    .expect("Non-frozen array");
-
                 result
-                    .push(group)
+                    .push(Self::capture_to_ruby_string(&capture))
                     .expect("Non-frozen array");
             }
         } else {

--- a/spec/rust_regexp_spec.rb
+++ b/spec/rust_regexp_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RustRegexp do
 
   describe "#scan" do
     examples = [
-      ['\w+:\d+', "ruby:123, rust:456", [["ruby:123"], ["rust:456"]]],
+      ['\w+:\d+', "ruby:123, rust:456", ["ruby:123", "rust:456"]],
       ['(\w+):(\d+)', 'ruby:123, rust:456', [["ruby", "123"], ["rust", "456"]]],
       ['(\w+):(\d+)', '123', []],
     ]


### PR DESCRIPTION
```ruby
# ruby
"ruby:123, rust:456".scan(/\w+:\d+/)
# => ["ruby:123", "rust:456"]

# before
RustRegexp.new('\w+:\d+').scan("ruby:123, rust:456")
# => [["ruby:123"], ["rust:456"]]

# after
RustRegexp.new('\w+:\d+').scan("ruby:123, rust:456")
# => ["ruby:123", "rust:456"]
```